### PR TITLE
v1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /.idea
 .idea
+dependency-reduced-pom.xml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_24" default="true" project-jdk-name="24" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/consentpvp.iml" filepath="$PROJECT_DIR$/consentpvp.iml" />
-    </modules>
-  </component>
-</project>

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 | `/pvp`            | Displays your PvP status and available actions.|
 | `/pvp enable`     | Enable PvP consent for yourself.               |
 | `/pvp disable`    | Disable PvP consent for yourself.              |
+| `/pvp death`      | Toggles whether PVP is disabled on death.      |
 
 ---
 
@@ -41,6 +42,31 @@
 | `consentpvp.admin`   | Allows admins to bypass cooldowns and combat restrictions.|
 
 ---
+
+## Configuration
+
+The `config.yml` file allows you to customize the plugin's behavior.
+
+```yaml
+pvp:
+  # If true, players will have their PVP consent disabled upon death.
+  disable-on-death: false
+
+cooldown:
+  # Duration in minutes before a player can toggle PVP consent again
+  duration: 5
+
+messages:
+  prefix: "<bold><gray>[<red>ConsentPVP<gray>]</bold> <white>"
+  pvp_enabled: "<green>PVP consent enabled."
+  pvp_disabled: "<red>PVP consent disabled."
+  on_cooldown: "<red>You must wait %time% before toggling PVP again."
+  pvp_not_consented_attacker: "<red>You tried to hit %player% but PVP is not consented."
+  pvp_not_consented_defender: "<red>%player% tried to hit you but PVP is not consented."
+  no_permission: "<red>You don't have permission to use this command."
+  pvp_death_toggle: "<green>PVP disable on death is now %status%."
+  pvp_disabled_on_death: "<red>Your PVP has been disabled due to your death."
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ messages:
   no_permission: "<red>You don't have permission to use this command."
   pvp_death_toggle: "<green>PVP disable on death is now %status%."
   pvp_disabled_on_death: "<red>Your PVP has been disabled due to your death."
+  pvp_status: "<white>Your PVP status is currently <green>%status%<white>."
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@
 
 | Command           | Description                                    |
 |-------------------|------------------------------------------------|
-| `/pvp`            | Displays your PvP status and available actions.|
+| `/pvp`            | Displays your PvP status.                      |
+| `/pvp status`     | Displays your PvP status.                      |
 | `/pvp enable`     | Enable PvP consent for yourself.               |
 | `/pvp disable`    | Disable PvP consent for yourself.              |
 | `/pvp death`      | Toggles whether PVP is disabled on death.      |

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -55,7 +55,7 @@
     </dependency>
   </dependencies>
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>21</java.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -55,7 +55,7 @@
     </dependency>
   </dependencies>
   <properties>
-    <java.version>21</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <java.version>21</java.version>
   </properties>
 </project>

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.modularsoft</groupId>
   <artifactId>consentpvp</artifactId>
   <name>ConsentPvP</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <build>
     <defaultGoal>clean package</defaultGoal>
     <resources>
@@ -55,7 +55,7 @@
     </dependency>
   </dependencies>
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>21</java.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.modularsoft</groupId>
   <artifactId>consentpvp</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <packaging>jar</packaging>
 
   <name>ConsentPvP</name>

--- a/src/main/java/org/modularsoft/consentpvp/ConsentPVP.java
+++ b/src/main/java/org/modularsoft/consentpvp/ConsentPVP.java
@@ -4,9 +4,7 @@ import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.modularsoft.consentpvp.commands.PVPCommand;
 import org.modularsoft.consentpvp.events.PVPEventListener;
-import org.modularsoft.consentpvp.util.CooldownManager;
-import org.modularsoft.consentpvp.util.MessageManager;
-import org.modularsoft.consentpvp.util.PVPManager;
+import org.modularsoft.consentpvp.util.*;
 
 public class ConsentPVP extends JavaPlugin {
 

--- a/src/main/java/org/modularsoft/consentpvp/ConsentPVP.java
+++ b/src/main/java/org/modularsoft/consentpvp/ConsentPVP.java
@@ -14,6 +14,7 @@ public class ConsentPVP extends JavaPlugin {
     private PVPManager pvpManager;
     private MessageManager messageManager;
     private EndCrystalManager endCrystalManager;
+    private RespawnAnchorManager respawnAnchorManager;
 
     private MiniMessage miniMessage;
     private String messagePrefix;
@@ -26,6 +27,7 @@ public class ConsentPVP extends JavaPlugin {
         this.pvpManager = new PVPManager(this);
         this.messageManager = new MessageManager(this);
         this.endCrystalManager = new EndCrystalManager();
+        this.respawnAnchorManager = new RespawnAnchorManager();
 
         this.miniMessage = MiniMessage.miniMessage();
 
@@ -64,6 +66,10 @@ public class ConsentPVP extends JavaPlugin {
 
     public EndCrystalManager getEndCrystalManager() {
         return endCrystalManager;
+    }
+
+    public RespawnAnchorManager getRespawnAnchorManager() {
+        return respawnAnchorManager;
     }
 
     public MiniMessage getMiniMessage() {

--- a/src/main/java/org/modularsoft/consentpvp/ConsentPVP.java
+++ b/src/main/java/org/modularsoft/consentpvp/ConsentPVP.java
@@ -13,6 +13,7 @@ public class ConsentPVP extends JavaPlugin {
     private CooldownManager cooldownManager;
     private PVPManager pvpManager;
     private MessageManager messageManager;
+    private EndCrystalManager endCrystalManager;
 
     private MiniMessage miniMessage;
     private String messagePrefix;
@@ -24,6 +25,7 @@ public class ConsentPVP extends JavaPlugin {
         this.cooldownManager = new CooldownManager(this);
         this.pvpManager = new PVPManager(this);
         this.messageManager = new MessageManager(this);
+        this.endCrystalManager = new EndCrystalManager();
 
         this.miniMessage = MiniMessage.miniMessage();
 
@@ -36,6 +38,7 @@ public class ConsentPVP extends JavaPlugin {
 
         // Register commands
         getCommand("pvp").setExecutor(new PVPCommand(this));
+        getCommand("pvp").setTabCompleter(new org.modularsoft.consentpvp.commands.PVPTabCompleter());
 
         // Register event listeners
         getServer().getPluginManager().registerEvents(new PVPEventListener(this), this);
@@ -57,6 +60,10 @@ public class ConsentPVP extends JavaPlugin {
 
     public MessageManager getMessageManager() {
         return messageManager;
+    }
+
+    public EndCrystalManager getEndCrystalManager() {
+        return endCrystalManager;
     }
 
     public MiniMessage getMiniMessage() {

--- a/src/main/java/org/modularsoft/consentpvp/ConsentPVP.java
+++ b/src/main/java/org/modularsoft/consentpvp/ConsentPVP.java
@@ -16,6 +16,7 @@ public class ConsentPVP extends JavaPlugin {
 
     private MiniMessage miniMessage;
     private String messagePrefix;
+    private boolean disablePvpOnDeath;
 
     @Override
     public void onEnable() {
@@ -25,16 +26,19 @@ public class ConsentPVP extends JavaPlugin {
         this.messageManager = new MessageManager(this);
 
         this.miniMessage = MiniMessage.miniMessage();
+
+        // Load configuration
+        saveDefaultConfig();
+        reloadConfig();
         this.messagePrefix = getConfig().getString("messages.prefix", "<gray>[<red>ConsentPVP<gray>] <white>");
+        this.disablePvpOnDeath = getConfig().getBoolean("pvp.disable-on-death", false);
+
 
         // Register commands
         getCommand("pvp").setExecutor(new PVPCommand(this));
 
         // Register event listeners
         getServer().getPluginManager().registerEvents(new PVPEventListener(this), this);
-
-        // Load configuration
-        saveDefaultConfig();
 
         // Schedule periodic cleanup every 5 minutes (6000 ticks)
         getServer().getScheduler().runTaskTimer(this, () -> {
@@ -61,5 +65,9 @@ public class ConsentPVP extends JavaPlugin {
 
     public String getMessagePrefix() {
         return messagePrefix;
+    }
+
+    public boolean isPvpDisabledOnDeath() {
+        return disablePvpOnDeath;
     }
 }

--- a/src/main/java/org/modularsoft/consentpvp/commands/PVPCommand.java
+++ b/src/main/java/org/modularsoft/consentpvp/commands/PVPCommand.java
@@ -35,13 +35,16 @@ public class PVPCommand implements CommandExecutor {
         MessageManager messageManager = plugin.getMessageManager();
 
         if (args.length == 0) {
-            player.sendMessage(miniMessage.deserialize(messagePrefix + "<red>Usage: /pvp <enable|disable>"));
+            showStatus(player, pvpManager, messageManager);
             return true;
         }
 
         String action = args[0].toLowerCase();
 
         switch (action) {
+            case "status":
+                showStatus(player, pvpManager, messageManager);
+                break;
             case "enable":
                 if (cooldownManager.isOnCooldown(player.getUniqueId())) {
                     String remainingTime = messageManager.getRemainingCooldownTime(player.getUniqueId());
@@ -77,10 +80,16 @@ public class PVPCommand implements CommandExecutor {
                 messageManager.sendMessage(player, "pvp_death_toggle", "%status%", status);
                 break;
             default:
-                player.sendMessage(miniMessage.deserialize(messagePrefix + "<red>Usage: /pvp <enable|disable|death>"));
+                player.sendMessage(miniMessage.deserialize(messagePrefix + "<red>Usage: /pvp <enable|disable|death|status>"));
                 break;
         }
 
         return true;
+    }
+
+    private void showStatus(Player player, PVPManager pvpManager, MessageManager messageManager) {
+        boolean hasConsent = pvpManager.hasConsent(player.getUniqueId());
+        String status = hasConsent ? "enabled" : "disabled";
+        messageManager.sendMessage(player, "pvp_status", "%status%", status);
     }
 }

--- a/src/main/java/org/modularsoft/consentpvp/commands/PVPCommand.java
+++ b/src/main/java/org/modularsoft/consentpvp/commands/PVPCommand.java
@@ -62,8 +62,22 @@ public class PVPCommand implements CommandExecutor {
                 cooldownManager.setCooldown(player.getUniqueId());
                 messageManager.sendMessage(player, "pvp_disabled");
                 break;
+            case "death":
+                if (!sender.hasPermission("consentpvp.admin")) {
+                    messageManager.sendMessage(player, "no_permission");
+                    return true;
+                }
+
+                boolean pvpOnDeath = plugin.getConfig().getBoolean("pvp.disable-on-death");
+                plugin.getConfig().set("pvp.disable-on-death", !pvpOnDeath);
+                plugin.saveConfig();
+                plugin.reloadConfig();
+
+                String status = !pvpOnDeath ? "enabled" : "disabled";
+                messageManager.sendMessage(player, "pvp_death_toggle", "%status%", status);
+                break;
             default:
-                player.sendMessage(miniMessage.deserialize(messagePrefix + "<red>Usage: /pvp <enable|disable>"));
+                player.sendMessage(miniMessage.deserialize(messagePrefix + "<red>Usage: /pvp <enable|disable|death>"));
                 break;
         }
 

--- a/src/main/java/org/modularsoft/consentpvp/commands/PVPCommand.java
+++ b/src/main/java/org/modularsoft/consentpvp/commands/PVPCommand.java
@@ -74,7 +74,6 @@ public class PVPCommand implements CommandExecutor {
                 boolean pvpOnDeath = plugin.getConfig().getBoolean("pvp.disable-on-death");
                 plugin.getConfig().set("pvp.disable-on-death", !pvpOnDeath);
                 plugin.saveConfig();
-                plugin.reloadConfig();
 
                 String status = !pvpOnDeath ? "enabled" : "disabled";
                 messageManager.sendMessage(player, "pvp_death_toggle", "%status%", status);

--- a/src/main/java/org/modularsoft/consentpvp/commands/PVPTabCompleter.java
+++ b/src/main/java/org/modularsoft/consentpvp/commands/PVPTabCompleter.java
@@ -1,0 +1,23 @@
+package org.modularsoft.consentpvp.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class PVPTabCompleter implements TabCompleter {
+
+    private static final String[] SUBCOMMANDS = { "enable", "disable", "death", "status" };
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length == 1) {
+            return StringUtil.copyPartialMatches(args[0], Arrays.asList(SUBCOMMANDS), new ArrayList<>());
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/modularsoft/consentpvp/events/PVPEventListener.java
+++ b/src/main/java/org/modularsoft/consentpvp/events/PVPEventListener.java
@@ -3,6 +3,7 @@ package org.modularsoft.consentpvp.events;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.*;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -140,6 +141,30 @@ public class PVPEventListener implements Listener {
         if (!nonConsentedDefenders.isEmpty()) {
             String joinedNames = String.join(", ", nonConsentedDefenders);
             plugin.getMessageManager().sendMessage(attacker, "pvp_not_consented_attacker_multiple", "%players%", joinedNames);
+        }
+    }
+
+    // Handles Mace AOE Smash Attack
+    @EventHandler
+    public void onEntitySweepAttack(EntityDamageByEntityEvent event) {
+        if (event.getCause() != EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK) return;
+        if (!(event.getEntity() instanceof Player)) return;
+        if (!(event.getDamager() instanceof Player)) return;
+
+        Player defender = (Player) event.getEntity();
+        Player attacker = (Player) event.getDamager();
+        PVPManager pvpManager = plugin.getPVPManager();
+
+        // Allow self-damage
+        if (attacker.getUniqueId().equals(defender.getUniqueId())) {
+            return;
+        }
+
+        if (!pvpManager.hasConsent(defender.getUniqueId()) || !pvpManager.hasConsent(attacker.getUniqueId())) {
+            event.setCancelled(true);
+            // Silently cancel the event to prevent message spam in chat.
+            // The original attacker and target are in a consensual fight.
+            // Bystanders should not be notified.
         }
     }
 }

--- a/src/main/java/org/modularsoft/consentpvp/events/PVPEventListener.java
+++ b/src/main/java/org/modularsoft/consentpvp/events/PVPEventListener.java
@@ -57,6 +57,12 @@ public class PVPEventListener implements Listener {
         else if (event.getDamager() instanceof TNTPrimed) {
             TNTPrimed tnt = (TNTPrimed) event.getDamager();
             if (tnt.getSource() instanceof Player) attacker = (Player) tnt.getSource();
+        } else if (event.getDamager() instanceof EnderCrystal) {
+            EnderCrystal crystal = (EnderCrystal) event.getDamager();
+            UUID ownerUUID = plugin.getEndCrystalManager().getOwner(crystal);
+            if (ownerUUID != null) {
+                attacker = plugin.getServer().getPlayer(ownerUUID);
+            }
         }
 
         // Allow self-damage (such as Ender Pearl teleportation)
@@ -149,6 +155,27 @@ public class PVPEventListener implements Listener {
             Player player = event.getEntity();
             plugin.getPVPManager().setConsent(player.getUniqueId(), false);
             plugin.getMessageManager().sendMessage(player, "pvp_disabled_on_death");
+        }
+    }
+
+    @EventHandler
+    public void onPlayerInteract(PlayerInteractEvent event) {
+        if (event.getAction().isRightClick() && event.getItem() != null && event.getItem().getType() == org.bukkit.Material.END_CRYSTAL) {
+            Player player = event.getPlayer();
+            plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
+                for (Entity entity : player.getNearbyEntities(5, 5, 5)) {
+                    if (entity instanceof EnderCrystal) {
+                        plugin.getEndCrystalManager().addCrystal((EnderCrystal) entity, player.getUniqueId());
+                    }
+                }
+            }, 1L);
+        }
+    }
+
+    @EventHandler
+    public void onEntityExplode(EntityExplodeEvent event) {
+        if (event.getEntity() instanceof EnderCrystal) {
+            plugin.getEndCrystalManager().removeCrystal((EnderCrystal) event.getEntity());
         }
     }
 }

--- a/src/main/java/org/modularsoft/consentpvp/events/PVPEventListener.java
+++ b/src/main/java/org/modularsoft/consentpvp/events/PVPEventListener.java
@@ -60,7 +60,7 @@ public class PVPEventListener implements Listener {
         }
 
         // Allow self-damage (such as Ender Pearl teleportation)
-        if (attacker == null || attacker.getUniqueId().equals(defender.getUniqueId())) {
+        if (attacker.getUniqueId().equals(defender.getUniqueId())) {
             return; // Do not cancel self-inflicted damage
         }
 

--- a/src/main/java/org/modularsoft/consentpvp/events/PVPEventListener.java
+++ b/src/main/java/org/modularsoft/consentpvp/events/PVPEventListener.java
@@ -60,7 +60,7 @@ public class PVPEventListener implements Listener {
         }
 
         // Allow self-damage (such as Ender Pearl teleportation)
-        if (attacker.getUniqueId().equals(defender.getUniqueId())) {
+        if (attacker == null || attacker.getUniqueId().equals(defender.getUniqueId())) {
             return; // Do not cancel self-inflicted damage
         }
 

--- a/src/main/java/org/modularsoft/consentpvp/events/PVPEventListener.java
+++ b/src/main/java/org/modularsoft/consentpvp/events/PVPEventListener.java
@@ -142,4 +142,13 @@ public class PVPEventListener implements Listener {
             plugin.getMessageManager().sendMessage(attacker, "pvp_not_consented_attacker_multiple", "%players%", joinedNames);
         }
     }
+
+    @EventHandler
+    public void onPlayerDeath(PlayerDeathEvent event) {
+        if (plugin.isPvpDisabledOnDeath()) {
+            Player player = event.getEntity();
+            plugin.getPVPManager().setConsent(player.getUniqueId(), false);
+            plugin.getMessageManager().sendMessage(player, "pvp_disabled_on_death");
+        }
+    }
 }

--- a/src/main/java/org/modularsoft/consentpvp/util/EndCrystalManager.java
+++ b/src/main/java/org/modularsoft/consentpvp/util/EndCrystalManager.java
@@ -1,0 +1,23 @@
+package org.modularsoft.consentpvp.util;
+
+import org.bukkit.entity.EnderCrystal;
+
+import java.util.UUID;
+import java.util.WeakHashMap;
+
+public class EndCrystalManager {
+
+    private final WeakHashMap<EnderCrystal, UUID> crystalOwners = new WeakHashMap<>();
+
+    public void addCrystal(EnderCrystal crystal, UUID owner) {
+        crystalOwners.put(crystal, owner);
+    }
+
+    public UUID getOwner(EnderCrystal crystal) {
+        return crystalOwners.get(crystal);
+    }
+
+    public void removeCrystal(EnderCrystal crystal) {
+        crystalOwners.remove(crystal);
+    }
+}

--- a/src/main/java/org/modularsoft/consentpvp/util/RespawnAnchorManager.java
+++ b/src/main/java/org/modularsoft/consentpvp/util/RespawnAnchorManager.java
@@ -1,0 +1,23 @@
+package org.modularsoft.consentpvp.util;
+
+import org.bukkit.block.Block;
+
+import java.util.UUID;
+import java.util.WeakHashMap;
+
+public class RespawnAnchorManager {
+
+    private final WeakHashMap<Block, UUID> anchorOwners = new WeakHashMap<>();
+
+    public void addAnchor(Block anchor, UUID owner) {
+        anchorOwners.put(anchor, owner);
+    }
+
+    public UUID getOwner(Block anchor) {
+        return anchorOwners.get(anchor);
+    }
+
+    public void removeAnchor(Block anchor) {
+        anchorOwners.remove(anchor);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,7 @@
+pvp:
+  # If true, players will have their PVP consent disabled upon death.
+  disable-on-death: false
+
 cooldown:
   # Duration in minutes before a player can toggle PVP consent again
   duration: 5
@@ -9,3 +13,6 @@ messages:
   on_cooldown: "<red>You must wait %time% before toggling PVP again."
   pvp_not_consented_attacker: "<red>You tried to hit %player% but PVP is not consented."
   pvp_not_consented_defender: "<red>%player% tried to hit you but PVP is not consented."
+  no_permission: "<red>You don't have permission to use this command."
+  pvp_death_toggle: "<green>PVP disable on death is now %status%."
+  pvp_disabled_on_death: "<red>Your PVP has been disabled due to your death."

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -16,3 +16,4 @@ messages:
   no_permission: "<red>You don't have permission to use this command."
   pvp_death_toggle: "<green>PVP disable on death is now %status%."
   pvp_disabled_on_death: "<red>Your PVP has been disabled due to your death."
+  pvp_status: "<white>Your PVP status is currently <green>%status%<white>."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,12 +1,12 @@
 name: ConsentPVP
-version: '1.0'
+version: '${project.version}'
 main: org.modularsoft.consentpvp.ConsentPVP
 author: "ModularSoft"
 description: "Respect in Battle: ConsentPVP for a Better Gaming Experience!"
 commands:
   pvp:
     description: Manage your PVP consent and requests.
-    usage: /pvp <enable|disable|death>
+    usage: /pvp <status|enable|disable|death>
     permission: consentpvp.use
     permission-message: You don't have permission to use this command.
 permissions:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: ConsentPVP
 version: '${project.version}'
 main: org.modularsoft.consentpvp.ConsentPVP
 author: "ModularSoft"
+api-version: "1.20"
 description: "Respect in Battle: ConsentPVP for a Better Gaming Experience!"
 commands:
   pvp:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,7 +6,7 @@ description: "Respect in Battle: ConsentPVP for a Better Gaming Experience!"
 commands:
   pvp:
     description: Manage your PVP consent and requests.
-    usage: /pvp <enable|disable>
+    usage: /pvp <enable|disable|death>
     permission: consentpvp.use
     permission-message: You don't have permission to use this command.
 permissions:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added /pvp status and default status display with no args.
  - Added /pvp death to toggle auto-disable on death (admin-only).
  - Tab completion for /pvp subcommands.
  - Consent enforcement extended to End Crystals, Respawn Anchors, potions, area clouds, sweep attacks.
  - Optional auto-disable PvP on player death.
- Documentation
  - Updated README with commands and new Configuration section.
- Configuration
  - New pvp.disable-on-death option and message templates.
- Chores
  - Updated plugin metadata (api-version 1.20, dynamic version); version bumped to 1.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->